### PR TITLE
tunnels.conf fixes

### DIFF
--- a/src/SaverImpl.cpp
+++ b/src/SaverImpl.cpp
@@ -9,7 +9,7 @@
 
 #include "mainwindow.h"
 
-SaverImpl::SaverImpl(MainWindow *mainWindowPtr_, QList<MainWindowItem*> * configItems_, std::map<std::string,TunnelConfig*>* tunnelConfigs_) :
+SaverImpl::SaverImpl(MainWindow *mainWindowPtr_, QSharedPointer<QList<MainWindowItem*>> configItems_, QSharedPointer<std::map<std::string,TunnelConfig*>> tunnelConfigs_) :
     configItems(configItems_), tunnelConfigs(tunnelConfigs_), confpath(), tunconfpath(), mainWindowPtr(mainWindowPtr_)
 {}
 

--- a/src/SaverImpl.h
+++ b/src/SaverImpl.h
@@ -6,6 +6,7 @@
 
 #include <QObject>
 #include "QList"
+#include "QSharedPointer"
 
 #include "mainwindow.h"
 #include "TunnelConfig.h"
@@ -17,14 +18,14 @@ class TunnelConfig;
 class SaverImpl : public Saver
 {
 public:
-    SaverImpl(MainWindow *mainWindowPtr_, QList<MainWindowItem*> * configItems_, std::map<std::string,TunnelConfig*>* tunnelConfigs_);
+    SaverImpl(MainWindow *mainWindowPtr_, QSharedPointer<QList<MainWindowItem*>> configItems_, QSharedPointer<std::map<std::string,TunnelConfig*>> tunnelConfigs_);
     virtual ~SaverImpl();
     virtual bool save(bool reloadAfterSave, const FocusEnum focusOn, const std::string& tunnelNameToFocus, QWidget* widgetToFocus);
     void setConfPath(QString& confpath_);
     void setTunnelsConfPath(QString& tunconfpath_);
 private:
-    QList<MainWindowItem*> * configItems;
-    std::map<std::string,TunnelConfig*>* tunnelConfigs;
+    QSharedPointer<QList<MainWindowItem*>> configItems;
+    QSharedPointer<std::map<std::string,TunnelConfig*>> tunnelConfigs;
     QString confpath;
     QString tunconfpath;
     MainWindow* mainWindowPtr;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -68,7 +68,10 @@ MainWindow::MainWindow(std::shared_ptr<std::iostream> logStream_, QWidget *paren
     ,tunconfpath()
     ,tunnelConfigs()
     ,tunnelsPageUpdateListener(this)
-    ,saverPtr(new SaverImpl(this, &configItems, &tunnelConfigs))
+    ,saverPtr(
+         new SaverImpl(this,
+                       QSharedPointer<QList<MainWindowItem*>>(&configItems),
+                       QSharedPointer<std::map<std::string,TunnelConfig*>>(&tunnelConfigs)))
 
 {
     assert(delayedSaveManagerPtr!=nullptr);
@@ -771,6 +774,10 @@ void MainWindow::loadAllConfigs(SaverImpl* saverPtr){
     ReadTunnelsConfig();
 
     //onLoggingOptionsChange();
+}
+
+void MainWindow::DisableTunnelsPage() {
+    ui->tunnelsScrollAreaWidgetContents->setEnabled(false);
 }
 
 void MainWindow::layoutTunnels() {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -1,9 +1,12 @@
 #ifndef MAINWINDOW_H
 #define MAINWINDOW_H
 
+#include <sstream>
+
 #include <QObject>
 #include <QMainWindow>
 #include <QPushButton>
+#include <QMessageBox>
 #include <QtCore/QVariant>
 #include <QtWidgets/QAction>
 #include <QtWidgets/QApplication>
@@ -756,7 +759,11 @@ private:
         }
         catch (std::exception& ex)
         {
-            LogPrint (eLogWarning, "Clients: Can't read ", tunConf, ": ", ex.what ());//TODO show err box and disable tunn.page
+            LogPrint (eLogWarning, "Clients: Can't read ", tunConf, ": ", ex.what ());
+            std::stringstream error;
+            error << "Error reading tunnels configuration file " << tunConf << ": " << ex.what();
+            QMessageBox::critical(this, "Error", error.str().c_str());
+            DisableTunnelsPage();
             return;
         }
 
@@ -853,13 +860,23 @@ private:
                                                               isUniqueLocal,
                                                               cryptoType);
                 }
-                else
-                    LogPrint (eLogWarning, "Clients: Unknown section type=", type, " of ", name, " in ", tunConf);//TODO show err box and disable the tunn gui
-
+                else {
+                    LogPrint (eLogWarning, "Clients: Unknown section type=", type, " of ", name, " in ", tunConf);
+                    std::stringstream error;
+                    error << "Error reading tunnels configuration file " << tunConf << ": Unknown section type " << type << " of " << name;
+                    QMessageBox::critical(this, "Error", error.str().c_str());
+                    DisableTunnelsPage();
+                    return;
+                }
             }
             catch (std::exception& ex)
             {
-                LogPrint (eLogError, "Clients: Can't read tunnel ", name, " params: ", ex.what ());//TODO show err box and disable the tunn gui
+                LogPrint (eLogError, "Clients: ", name, " params: ", ex.what ());
+                std::stringstream error;
+                error << "Error reading tunnels configuration file " << tunConf << ": Can't read tunnel named '" << name << "': " << ex.what();
+                QMessageBox::critical(this, "Error", error.str().c_str());
+                DisableTunnelsPage();
+                return;
             }
         }
     }
@@ -878,6 +895,8 @@ private:
     //void onLoggingOptionsChange() {}
 
     SaverImpl* saverPtr;
+
+    void DisableTunnelsPage();
 };
 
 #endif // MAINWINDOW_H


### PR DESCRIPTION
* Now shows a message box and disables tunnels UI control on errors;
* QSharedPointer instead of simple C pointer within SaverImpl.